### PR TITLE
Maybe shoule disabling cuDNN

### DIFF
--- a/train_SemanticKITTI.py
+++ b/train_SemanticKITTI.py
@@ -18,6 +18,7 @@ from utils.metric import compute_acc, IoUCalculator
 from network.RandLANet import Network
 from network.loss_func import compute_loss
 
+torch.backends.cudnn.enabled = False
 
 warnings.filterwarnings("ignore")
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
Experiments on torch1.60 with 2080ti show that disabling cuDNN results in a significant training speedup, however it is uncertain whether this affects performance. However, it's very strange and no idea about why cause it.
Top is set torch.backends.cudnn.enabled = False. 
Under is  default Settings.
![QQ截图20211007200226](https://user-images.githubusercontent.com/65054204/136381643-c67e726b-47b9-41ee-84c9-d8753239f7d4.png)
.

![QQ截图20211007202631](https://user-images.githubusercontent.com/65054204/136383822-1b778c6f-8446-4f44-8d7c-8c38a939f4d7.png)

