### PR TITLE
Ensure that the sequences argument is a list

### DIFF
--- a/evaluate_SemanticKITTI.py
+++ b/evaluate_SemanticKITTI.py
@@ -55,6 +55,10 @@ def get_args():
     )
     FLAGS = parser.parse_args()
 
+    # make sure that sequences is actually a list
+    if not isinstance(FLAGS.sequences, list):
+        FLAGS.sequences = [FLAGS.sequences]
+    
     # fill in real predictions dir
     if FLAGS.predictions is None:
         FLAGS.predictions = FLAGS.dataset


### PR DESCRIPTION
This fixes an bug in the script, where sequences is treated as a string and get_labels iterates over its characters. This results in get_labels not finding the label files.